### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/backend-common/src/main/java/org/exchange/app/backend/common/keycloak/DisabledSecurityConfiguration.java
+++ b/backend-common/src/main/java/org/exchange/app/backend/common/keycloak/DisabledSecurityConfiguration.java
@@ -23,8 +23,7 @@ public class DisabledSecurityConfiguration {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable)
-        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll());
     return http.build();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/tomasz-franek/exchange-platform/security/code-scanning/1](https://github.com/tomasz-franek/exchange-platform/security/code-scanning/1)

In general, the fix is to stop globally disabling CSRF protection on the `HttpSecurity` object and let Spring Security’s default CSRF mechanisms operate, or replace the blanket disable with a more targeted configuration that only relaxes CSRF where it is demonstrably safe (for example, for read‑only endpoints or for stateless, non‑browser clients that do not use cookies).

The minimal and safest change, without altering existing behavior more than necessary, is to remove the explicit disabling of CSRF from the filter chain configuration. In this file, that means changing the `filterChain` method to no longer call `http.csrf(AbstractHttpConfigurer::disable)`. Since no custom CSRF configuration is needed, we can simply rely on Spring Security’s default CSRF behavior. Concretely, in `backend-common/src/main/java/org/exchange/app/backend/common/keycloak/DisabledSecurityConfiguration.java`, modify the `filterChain` method so that it only configures CORS and authorization, leaving CSRF untouched. No additional imports or helper methods are required because we are removing, not adding, configuration steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
